### PR TITLE
Update scripts to match firmware introduced in 2019 NCSS

### DIFF
--- a/quokka/py/update.bat
+++ b/quokka/py/update.bat
@@ -1,11 +1,6 @@
 
 rem -- This is a script for updating your pyboard.
 rem -- Note: lines starting with 'rem' are comments in bat files.
-rem
-rem -- If you've made a change to the quokka libraries or drivers, or
-rem -- if this is the first time you've used the pyboard, 
-rem -- run update_libraries.bat first.
-
 
 rem -- update main.py
 copy main.py D:\main.py

--- a/quokka/py/update.sh
+++ b/quokka/py/update.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-# Copies a file to the quokka as main.py (and optionally adds all the quokka libraries).
+# Copies a file to the quokka as main.py.
 # e.g.   ./update.sh demos/buttons-display-neopixels.py
 # After copying everything, it connects the serial console so you can Ctrl-C/Ctrl-D.
-
-# For setting up a new Quokka, pass the -u flag to the script.
-# This copies all libraries and the selected file as as main.py.
 
 # Disable connecting the serial console with -n
 
@@ -32,24 +29,6 @@ fi
 
 # If using an SD card with your quokka, update this volume name
 VOL_NAME="PYBFLASH"
-
-# If the -u flag is given, update the libraries
-# Otherwise, only the main files are updated
-if [ "$1" = "-u" ]; then
-    sed "/^\W*#/d" quokka.py | sed "/^\W*$/d" > strip_quokka.py
-    sed "/^\W*#/d" boot.py | sed "/^\W*$/d" > strip_boot.py
-    $CP strip_quokka.py /$VOL_DIR/$VOL_NAME/quokka.py
-    $CP strip_boot.py /$VOL_DIR/$VOL_NAME/boot.py
-    rm strip_quokka.py strip_boot.py
-    mkdir -p /$VOL_DIR/$VOL_NAME/drivers
-    for file in drivers/*.py; do
-        file=`basename $file`
-        sed "/^\s*#/d" drivers/$file | sed "/^\s*$/d" > drivers/strip_$file
-        $CP drivers/strip_$file /$VOL_DIR/$VOL_NAME/drivers/$file
-        rm drivers/strip_$file
-    done
-    shift
-fi
 
 CONNECT_SERIAL=1
 # If the -n flag is given, remember to skip the serial console

--- a/quokka/py/update_libraries.bat
+++ b/quokka/py/update_libraries.bat
@@ -1,8 +1,0 @@
-rem -- download 'sync' from SysInternals -- short link http://goo.gl/32dbAJ
-
-copy quokka.py D:\
-copy boot.py D:\
-mkdir D:\drivers
-copy drivers\*.py D:\drivers
-
-sync D:\


### PR DESCRIPTION
This PR updates the Quokka scripts to match the current state of the Quokka firmware (used in both 2019 and 2020 NCSS)

It'd also be useful to link to https://github.com/jimmo/micropython/tree/ncss-2019-quokka/ports/stm32/boards/PYBLITEV10-QUOKKA/modules ([permalink](https://github.com/jimmo/micropython/tree/b7fa66a63758f66521a3b21d014660d1d71eb8a8/ports/stm32/boards/PYBLITEV10-QUOKKA/modules)) somewhere. I definitely use them for reference often.

That should also be migrated into the NCSS org.